### PR TITLE
fix(classAces): fixing broken Class permission granting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /phpunit.xml
 /vendor
 /build

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" />
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" />
-</project>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ $aclManager = $container->get('projecta_acl.manager');
 $aclManager->manageObjectAces()
     ->grant($domainObject, MaskBuilder::MASK_OWNER, $user);
 ```
+Granting permission to a class is typically done by supplying an instance of a document of that class.
+This requires you have an instance already, so we made it also possible to supply an ObjectIdentity of type 'class'
+
+```php
+...
+$oid    =   new ObjectIdentity( 'class' , 'Acme\\SomeBundle\\Document\\Comment');
+
+$aclManager->manageClassAces()
+  ->grant($oid, MaskBuilder::MASK_CREATE, $user);
+```
+This creates an ObjectIdentity in the MongoDB with Identifier 'class' and the type will 'Acme\\SomeBundle\\Document\\Comment'
 
 ## Documentation
 

--- a/Security/Acl/Manager/AceManager/AbstractAceManager.php
+++ b/Security/Acl/Manager/AceManager/AbstractAceManager.php
@@ -11,6 +11,7 @@
 
 namespace ProjectA\Bundle\AclBundle\Security\Acl\Manager\AceManager;
 
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
@@ -33,7 +34,7 @@ abstract class AbstractAceManager implements AceManagerInterface
     /**
      * @var MutableAclProviderInterface
      */
-    private $provider;
+    protected $provider;
 
     /**
      * @var ObjectIdentityRetrievalStrategyInterface
@@ -51,9 +52,9 @@ abstract class AbstractAceManager implements AceManagerInterface
      * @param string                                   $defaultStrategy
      */
     public function __construct(
-        MutableAclProviderInterface $provider,
-        ObjectIdentityRetrievalStrategyInterface $objectIdentityStrategy,
-        $defaultStrategy
+      MutableAclProviderInterface $provider,
+      ObjectIdentityRetrievalStrategyInterface $objectIdentityStrategy,
+      $defaultStrategy
     ) {
         $this->provider = $provider;
         $this->objectIdentityStrategy = $objectIdentityStrategy;
@@ -209,7 +210,7 @@ abstract class AbstractAceManager implements AceManagerInterface
      */
     protected function findAcl($object)
     {
-        $identity = $this->createObjectIdentity($object);
+        $identity = $this->ensureObjectIdentity($object);
 
         try {
             $acl = $this->provider->findAcl($identity);
@@ -230,7 +231,7 @@ abstract class AbstractAceManager implements AceManagerInterface
     {
         $acl = $this->findAcl($object);
         if (null === $acl) {
-            $identity = $this->createObjectIdentity($object);
+            $identity = $this->ensureObjectIdentity($object);
             $acl = $this->provider->createAcl($identity);
             $this->checkAclType($acl);
         }
@@ -275,10 +276,26 @@ abstract class AbstractAceManager implements AceManagerInterface
      *
      * @throws \LogicException if the provider is not creating mutable acl classes
      */
-    private function checkAclType(AclInterface $acl)
+    protected function checkAclType(AclInterface $acl)
     {
         if (!$acl instanceof MutableAclInterface) {
             throw new \LogicException('The acl provider needs to create acls of type MutableAclInterface');
         }
+    }
+
+    /**
+     * turn object into an ObjectIdentity if it is not already
+     *
+     * @param $object
+     *
+     * @return ObjectIdentity
+     */
+    protected function ensureObjectIdentity($object) {
+        if($object instanceof ObjectIdentity) {
+            $oid = $object;
+        } else {
+            $oid = new ObjectIdentity( 'class' , ClassUtils::getRealClass( get_class( $object ) ) );
+        }
+        return $oid;
     }
 }

--- a/Security/Acl/Manager/AceManager/AbstractAceManager.php
+++ b/Security/Acl/Manager/AceManager/AbstractAceManager.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * @author Daniel Tschinder <daniel@tschinder.de>

--- a/Security/Acl/Manager/AceManager/AbstractAceManager.php
+++ b/Security/Acl/Manager/AceManager/AbstractAceManager.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Doctrine\Common\Util\ClassUtils;
 
 /**
  * @author Daniel Tschinder <daniel@tschinder.de>
@@ -295,7 +294,7 @@ abstract class AbstractAceManager implements AceManagerInterface
         if($object instanceof ObjectIdentity) {
             $oid = $object;
         } else {
-            $oid = new ObjectIdentity( 'class' , ClassUtils::getRealClass( get_class( $object ) ) );
+            $oid = $this->createObjectIdentity($object);
         }
         return $oid;
     }

--- a/Security/Acl/Manager/AceManager/ClassAceManager.php
+++ b/Security/Acl/Manager/AceManager/ClassAceManager.php
@@ -14,8 +14,6 @@ namespace ProjectA\Bundle\AclBundle\Security\Acl\Manager\AceManager;
 use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Doctrine\Common\Util\ClassUtils;
-use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 
 /**
  * @author Daniel Tschinder <daniel@tschinder.de>

--- a/Security/Acl/Manager/AceManager/ClassAceManager.php
+++ b/Security/Acl/Manager/AceManager/ClassAceManager.php
@@ -14,6 +14,8 @@ namespace ProjectA\Bundle\AclBundle\Security\Acl\Manager\AceManager;
 use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 
 /**
  * @author Daniel Tschinder <daniel@tschinder.de>
@@ -29,16 +31,28 @@ class ClassAceManager extends AbstractAceManager
     }
 
     /**
+     * @param object $object
+     *
+     * @return MutableAclInterface
+     */
+    protected function findOrCreateAcl($object)
+    {
+        $oid = $this->ensureObjectIdentity($object);
+
+        return parent::findOrCreateAcl($oid);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function insertAce(
-        MutableAclInterface $acl,
-        SecurityIdentityInterface $sid,
-        $mask,
-        $field = null,
-        $index = 0,
-        $granting = true,
-        $strategy = null
+      MutableAclInterface $acl,
+      SecurityIdentityInterface $sid,
+      $mask,
+      $field = null,
+      $index = 0,
+      $granting = true,
+      $strategy = null
     ) {
         if ($field) {
             $acl->insertClassFieldAce($field, $sid, $mask, $index, $granting, $strategy ?: $this->defaultStrategy);

--- a/Tests/Security/Acl/Manager/AceManager/ClassAceManagerTest.php
+++ b/Tests/Security/Acl/Manager/AceManager/ClassAceManagerTest.php
@@ -27,6 +27,14 @@ class ClassAceManagerTest extends AbstractSecurityTest
         $this->assertTrue($this->manager->isGranted('EDIT', $this->object));
     }
 
+    public function testGrantCreateMask()
+    {
+        $this->classmanager->grant($this->object, MaskBuilder::MASK_CREATE, $this->token);
+
+        $this->assertTrue($this->manager->isGranted('CREATE', $this->object));
+        $this->assertFalse($this->manager->isGranted('EDIT', $this->object));
+    }
+
     public function testGrantMultipleMask()
     {
         $maskBuilder = new MaskBuilder();


### PR DESCRIPTION
* specialized the findOrCreateAcl for Classes because it has to look for or create an Oid for a class not an instance with an Id
* added posibility to supply an ObjectIdentity to grant so that you don't need an instantiated document to create a Class based permisson